### PR TITLE
(chore) Update Cargo.toml use repository instead of homepage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
     "Thomas Kehrenberg <tmke8@posteo.net>",
 ]
 license = "Apache-2.0 OR MIT"
-homepage = "https://github.com/tmke8/stable-arena"
+repository = "https://github.com/tmke8/stable-arena"
 keywords = ["arena", "allocator"]
 categories = ["memory-management"]
 readme = "README.md"


### PR DESCRIPTION
More explanation: https://github.com/szabgab/rust-digger/issues/88